### PR TITLE
Fix react-toolbox css build.

### DIFF
--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,6 +1,10 @@
+let path = require('path');
+
+// Customize global RT settings here
 let reactToolboxVariables = {
     'button-height': '30px'
 };
+
 module.exports = {
     type: 'react-component',
     webpack: {
@@ -8,7 +12,7 @@ module.exports = {
             css: [
                 // Create a rule which provides the specific setup react-toolbox v2 needs
                 {
-                    include: /react-toolbox/,
+                    include: [/react-toolbox/, path.join(__dirname, 'src')],
                     // css-loader options
                     css: {
                         modules: true,
@@ -28,10 +32,11 @@ module.exports = {
                         ]
                     }
                 },
+                // XXX This is interfering with the rule above.
                 // Create a catch-all rule for other CSS
-                {
-                    exclude: /react-toolbox/
-                }
+//                {
+//                    exclude: [/react-toolbox/, path.join(__dirname, 'src')]
+//                }
             ]
         }
     },

--- a/src/RTButtonTheme.css
+++ b/src/RTButtonTheme.css
@@ -1,0 +1,4 @@
+/* Example theme. */
+.button {
+    font-weight: bold;
+}

--- a/src/XenaGoApp.js
+++ b/src/XenaGoApp.js
@@ -17,7 +17,8 @@ let xenaQuery = require('ucsc-xena-client/dist/xenaQuery');
 let {datasetSamples,  sparseData} = xenaQuery;
 import {pick, pluck, flatten} from 'underscore';
 import {SortSelector} from "./components/SortSelector";
-import Button from "react-toolbox/lib/button/Button";
+import {Button} from "react-toolbox/lib/button";
+import RTButtonTheme from "./RTButtonTheme.css"
 
 let mutationKey = 'simple somatic mutation';
 
@@ -253,7 +254,7 @@ export default class XenaGoApp extends PureComponent {
                 {this.state.loadState === 'loading' ? 'Loading' : ''}
                 {this.state.loadState === 'loaded' &&
                 <div>
-                    <Button raised>What Up</Button>
+                    <Button theme={RTButtonTheme} raised>What Up</Button>
                     <h2>Cohorts</h2>
                     <CohortSelector cohorts={this.state.cohortData}
                                     selectedCohort={this.state.selectedCohort}


### PR DESCRIPTION
Notes:
Changed import of Button to get default styled instead of unstyled component. RT convention is to provide both styled and unstyled components, at different import paths.
Disabled nwb catch-all css rule, which was mucking up postcss, for reasons I don't understand.
Enabled css modules in ./src.
Added example of overriding the default theme, by passing a 'theme' property to Button.

Note that override a theme sometimes requires writing a selector that is more specific than the selector in the default theme, i.e. normal css specificity rules apply.